### PR TITLE
chore: add articles from EngineHouse Substack

### DIFF
--- a/_posts/2015-12-11-using-selenium-webdriver-with-mocha.markdown
+++ b/_posts/2015-12-11-using-selenium-webdriver-with-mocha.markdown
@@ -85,7 +85,7 @@ describe('my blog', function() {
 });
 ```
 
-(For more examples see [Writing Tests](http://bit.ly/1OQozM4) and [Promises](http://bit.ly/1OQoF6r) in the [WebDriverJS User’s Guide](http://bit.ly/1OQoF6r).)
+(For more examples see [Writing Tests](http://bit.ly/1OQozM4) and [Promises](http://bit.ly/1OQoF6r) in the [WebDriverJS User's Guide](http://bit.ly/1OQoF6r).)
 
 ## Improvements to the Template
 

--- a/_posts/2022-06-07-destructure-why-dont-you.markdown
+++ b/_posts/2022-06-07-destructure-why-dont-you.markdown
@@ -1,0 +1,60 @@
+---
+layout: post
+title:  "Destructure, Why Don't You"
+date:   2022-06-07 14:08:00 +0000
+comments: true
+tags: 
+ - javascript
+---
+
+There is nothing really wrong with this:
+
+```js
+const names = users.map(
+  /**
+   * @param {User} user - A user
+   */
+  (user) => user.name
+)
+```
+
+We're taking an array of people objects and creating a new array that contains the value of the `name` property from each person.
+
+However, there are a couple of reasons that we might prefer something slightly different.
+
+The first is that we have now introduced a named variable that serves no purpose other than being something on which we can hang our selection of the `name` attribute. We have created a variable called `user` only so that we can then perform `user.name`.
+
+This is distracting, partly because we need to look at `user` when looking at the code (since we don't know whether it represents something important), but also because we now really need to have our wits about us when reviewing--the function could do anything to the `User` instance and we need to be really sure about whether it's intentional or not.
+
+If this was the only way we could achieve what we wanted then it would be fine, and we'd just move on.
+
+But in recent versions of JavaScript it is possible to achieve the same end without introducing the extra variable. We can do this by using destructuring.
+
+A version of our function that uses destructuring would look like this:
+
+```js
+const names = users.map(
+  /**
+   * @param {% raw %}{{ name: string }}{% endraw %} name - A name of something
+   */
+  ({ name }) => name
+)
+```
+
+With this approach the only value that is available to the function is `name`--it does not have access to the full object. It's pretty clear to anyone reviewing this code that we don't intend to do anything other than extract the `name` property.
+
+What's more, the type of the object passed in to the function is 'anything that has a `name` property'. Our previous function could only accept something of type `User`, but with our new function we can accept many different types of object, as long as they have a `name`:
+
+```js
+/**
+ * Get the name from any object that has one.
+ * @param {% raw %}{{ name: string }}{% endraw %} name - A name of something
+ */
+const getName = ({ name }) => name
+
+const userNames = users.map(getName)
+const countryNames = countries.map(getName)
+const filmNames = films.map(getName)
+```
+
+We've only made a small change, but by using destructuring we've obtained some really important benefits: we've helped our code reviews, deepened our understanding of our function and made it easier to manage in the future.

--- a/_posts/2022-06-08-dont-feel-bad-no-one-else-can-estimate-either.markdown
+++ b/_posts/2022-06-08-dont-feel-bad-no-one-else-can-estimate-either.markdown
@@ -1,0 +1,39 @@
+---
+layout: post
+title:  "Don't Feel Bad, No-one Else Can Estimate Either"
+date:   2022-06-08 14:08:00 +0000
+comments: true
+tags: 
+ - agile
+ - kanban
+---
+
+It's time to stop beating ourselves up about how bad we are at estimating project delivery.
+
+<!-- snip -->
+
+Have you _ever_ been on a project that is good at estimating?
+
+I know everyone _thinks_ they have, but I reckon if we're really honest we'd admit that even when we seem to get it right, someone, somewhere in our team has probably compensated for poor estimation by working longer hours.
+
+That's not to say that we can skip deadlines.
+
+There will be situations where they are unavoidable; software is discontinued, certificates run out, millennia come and go, and market opportunities arise.
+
+And if deadlines don't happen to us, they still happen to others, which means there will be times when we have to work to a deadline simply because another team is working to a deadline.
+
+But for the most part estimates and deadlines are setting ourselves up for failure.
+
+And that's not because some people are 'bad' at estimating while others are 'good'. It's because estimating how long a particular task will take, with any accuracy, is near enough impossible.
+
+If you want to be a bit scientific about it, in most projects the variation between the *lead time* for tasks (i.e., the time measured from when the team committed to doing the work, through to its delivery) is far greater than the variation between the task-work itself. To put it differently, even if you were always 100% accurate in your estimates of how much effort a task would take, you could still be wrong every time when it comes to estimating how much time will elapse between getting the task from the customer and delivering back a finished item.
+
+So what's the answer? Do we simply remove estimation altogether?
+
+We don't, but what we do instead is frame the answer differently.
+
+To do this we must measure lead time--ideally tracking different lead times for the different types of work we are involved in. Once we're armed with historical data then the answer to the question _how long will this task take?_ requires no skill! The answer becomes simply this: _on average, this type of task usually takes this number of days_.
+
+Alongside collecting this data we should reduce lead times, since this will reduce their variability and make the range of possibilities narrower. There is plenty that can be done in this area, from working in smaller batches of committed work (which will immediately reduce lead time), through to improving quality (which reduces lead time by reducing rework).
+
+Topics for another day--but for now, it's enough to say that if you are providing fixed delivery dates based on your attempts to estimate, then it's almost inevitable that both your customers _and_ your developers are going to be very disappointed.

--- a/_posts/2022-08-25-golden-age-of-software-development-practice.markdown
+++ b/_posts/2022-08-25-golden-age-of-software-development-practice.markdown
@@ -1,0 +1,30 @@
+---
+layout: post
+title:  "The Golden Age of Software Development Practice"
+date:   2022-08-25 14:08:00 +0000
+comments: true
+tags: 
+ - agile
+ - ddd
+ - kanban
+---
+
+When we say that software is in a golden age, we are usually speaking in awe of [programs that allow us to create images of anything, just with words](https://openai.com/blog/dall-e/), or [software that can beat us at games we've been playing for thousands of years](https://www.deepmind.com/research/highlighted-research/alphago).
+
+Those in the industry will also no doubt acknowledge that it's a golden age for tools, as well. And that doesn't just mean the majestic Kubernetes; alongside it we have an embarrassment of applications, languages and services that make the life of any developer easier...and dare we say it? More fun.
+
+But in some ways the richness of thinking _about_ software development is also indicative of a golden age of processes. (It might even be argued that many of the software breakthroughs we have seen in recent years were only possible because of improvements in process.) We are seeing not only a growth in ideas and concepts, but a fertile interaction between them as those ideas and concepts overlap.
+
+A great example can be seen in the book [Team Topologies](https://teamtopologies.com/book).
+
+The general thrust of the book is that you should decide on a product's architecture first, and _then_ structure your teams in order to build it.
+
+It's a simple idea, and is based on cheekily taking advantage of [Melvin E. Conway's adage that an organisation will always create products that reflect its internal structure](https://en.wikipedia.org/wiki/Conway%27s_law)--instead of being victims of this law, the authors Matthew Skelton and Manuel Pais urge us to make use of it, by flipping it on its head in an activity they call a 'reverse Conway manoeuvre'.
+
+If this idea was the whole show, then you'd barely need a blog post, never mind a book. But what the authors do exceptionally well is to look at best practices for software architecture and then present various team structures and modes of communication that would help to implement those practices.
+
+This is exciting in itself, but the reason I feel we are entering a golden age of _practice_ is that many of the approaches to team structure and communication presented in the book align perfectly with ideas from [Domain-driven Design](https://martinfowler.com/bliki/DomainDrivenDesign.html). Instead of trying to sell us the latest snake oil and then moving on, the Team Topology project consciously _builds_ on established ideas from DDD, showing how they can be manifest in real teams, working on real projects, building real products.
+
+And it doesn't end there. The book contains concepts from Kanban, refers to DevOps science by way of the excellent [Accelerate](https://en.wikipedia.org/wiki/Accelerate_(book)), brings in SRE-thinking and platform engineering, and much more besides.
+
+If we are to do justice to the riches we developers have at our fingertips--by creating great products--we will need to make it easier for many, many more people to get involved and be immediately productive. As a consequence, processes and team-building will be an important area for the next phase of product development, making it crucial that new ideas in this space both integrate, and build on others.

--- a/_posts/2022-09-09-correctly-calculating-change-fail-rate.markdown
+++ b/_posts/2022-09-09-correctly-calculating-change-fail-rate.markdown
@@ -1,0 +1,92 @@
+---
+layout: post
+title:  "Correctly Calculating Change Fail Rate"
+date:   2022-09-09 14:08:00 +0000
+comments: true
+tags: 
+ - dora
+---
+
+CFR is a valuable metric, but if we forget its purpose we can calculate it incorrectly.
+
+<!-- snip -->
+
+When looking at how to improve the performance of application delivery it can be tempting to take a big-bang approach. Perhaps there should be a complete reorganisation, with new roles, and new teams with clever names based on Marvel characters or mountain ranges?
+
+Or maybe the code should be re-written from scratch, using some new library or framework? Or even re-written using some _old_ library or framework, so that we can return to those golden times when things seemed simpler and we cursed a lot less.
+
+And whether it's teams or code, there will probably be a suggestion in there somewhere for a big Agile-shakeup, involving more retrospectives and better ticket estimation Poker T-shirt wearing.
+
+But if we know one thing for certain, it's that when it comes to secret sauce, there is no secret sauce. Often, to get started we simply need a metric that is easy to capture, and that is a good indicator of what we do.
+
+## Accelerate, The Science of Lean Software
+
+A fantastic source of such metrics is the book _Accelerate_, by Nicole Forsgren, Jez Humble and Gene Kim. If you don't have a copy, go get one. I'd recommend getting an actual printed copy (don't share), because you will be underlining, and writing all over it for quite a long time.
+
+The metric I'm particularly interested in for this post is what they call in the book _Change Fail Rate_. And what I mainly want to look at is the confusion around how it is calculated.
+
+## What Is Change Fail Rate?
+
+Change Fail Rate (CFR) is a measure of how successful your team is when it makes changes to production code.
+
+If you're following along with DevOps thinking, or more specifically the SRE approach, you'll know that the major tension we face is between the conflicting desires of application stability and adding new features.
+
+At one extreme, if we add no new features to a stable application, then we will usually continue to have a stable application. And at the other extreme, if we rapidly add new features without paying attention to how we go about it, then we'll keep undermining our application.
+
+Somewhere in the middle will be the sweet spot for your particular application, based on your organisation's appetite for risk; stability for an online streaming service means something different to stability for an ecommerce site, which is different again to what stability means for an online trading platform.
+
+## Preventing Problems Reaching Production
+
+So CFR is used to reflect what happens when you go to make a change.
+
+But we're not interested (for this metric) in splitting up the whole history of a change, from code review to merge to test to deployment. We're concerned here with the final step; when we come to deploy new features, how often do we disrupt the current application?
+
+To put it in terms of the tension between stability and features, how often does our process of adding enhancements actually result in instability in our service?
+
+According to _Accelerate_ this metric correlates strongly with the general health and maturity of your software delivery process (p. 38), which of course makes sense; if you have high quality, well-tested code, combined with careful coordination between teams and APIs, then you should be in a good position to avoid releasing problems into production. Teams that are high and medium performing across their delivery process will have a CFR of between 0-15%, whilst low performing teams will have a CFR of 31-45% (p. 19).
+
+(It's worth saying that a CFR of 0% is not necessarily a sign of perfection. If we _never_ have to rollback or hotfix, then we might be going too slow with our new features! As the book shows, even high performing teams might have a CFR of up to 15%.)
+
+## Incorrectly Calculating CFR
+
+The first thing we will no doubt think of when making this calculation is that we should tot up our deployments, releases or launches. Whatever terminology you use, it seems obvious to begin with the number of deployments we've done, and work out a ratio against those deployments that were unsuccessful.
+
+Let's say we plan to deploy once a month. Let's also say that we have carried out 10 deployments this year, comprising the one a month that we expected (say for January to August), plus two additional deployments to resolve problems (say in April and June).
+
+The expectation then is that the CFR is 20%, since there were 2 failures out of our total of 10 deployments.
+
+But this is wrong, and can seriously flatter the situation.
+
+## Better and Worse
+
+To understand why this calculation is wrong, let's go back to the goal; we want to understand how many of our attempts to change our application resulted in instability. Or in terms of the tension...when we were trying to make things better with new features, how often did we actually make things worse?
+
+To find out how often we tried to make things better, we simply tot up the number of planned deployments. In our example we tried 8 times to make things better, with our monthly releases from January to August.
+
+The next question is how many of those attempts to release new features resulted in a problem, such as needing to apply a hotfix, or roll back our release?
+
+We know that's 2--April and June.
+
+So our CFR--the number of attempted changes that caused a problem--is not 20%, but 25%, i.e., 2 failures divided by 8 successes.
+
+That difference of 5% probably doesn't seem like a lot, and you might be thinking that as long as you get this figure roughly right, it's still a useful metric. But to see the problem, let's try some other scenarios.
+
+Let's imagine that in each of our monthly deployments, we had to carry out a rollback or hotfix. Using our erroneous calculation we might imagine that we have a CFR of 50%, since we have 8 failures divided by 16 deployments.
+
+It's a lot, but maybe it's not terrible. After all, half of our deployments have been successful.
+
+But the reality is that we have a CFR of 100%.
+
+It's easy to see why; we made 8 attempts to deploy new features, and each of those attempts resulted in a rollback or hotfix. In other words, every single one of our deployments caused a ‘change fail'. And that's 100% in anyone's book.
+
+If it's still not quite gelling, then think of it the other way around; if we didn't have to apply any hotfixes or rollbacks, what would be the number of deployments? That's obvious, you say...it's 8. We planned to do one per month, and we did.
+
+Now, what if in addition to those 8 deployments we had to apply 8 hotfixes or rollbacks? How many deployments are there now?
+
+We can't say 16. We can't say that by failing to deploy smoothly 8 times, we've effectively doubled our number of deployments!
+
+To put it yet another way, if we had a target to deploy twice a month, have we now met that target by failing to deploy correctly every month?
+
+## Conclusion
+
+CFR is a powerful metric to track. Not only will it help to improve your release process, but since there is a strong correlation with other software delivery processes, it's a good first metric to look at if you went to start improving across the board. But for the metric to be useful it must be calculated correctly, and to do that we need to remember what exactly we are measuring; we are quantifying how often the changes we make to our application actually introduce instability.


### PR DESCRIPTION
As part of centralising blog posts, move the articles from the [EngineHouse Substack](https://enginehouse.substack.com/).